### PR TITLE
Investigate py27 failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_args = dict(
         'jupyter_client',
         'ipykernel',
         'nbformat',
-        'nbconvert',
+        'nbconvert ==5.3.1',
         'pyflakes',
         'requests',
         'beautifulsoup4'


### PR DESCRIPTION
Sticking at nbconvert 5.3.1 rather than moving to 5.4 fixes the py27 build. Not suggesting this change should be merged, just recording what I found - I'm currently out of time to investigate any further.