### PR TITLE
Add coverage to travis and fix coverage collection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,11 @@ jobs:
     env: TOX_ENV=dev
 
   - <<: *default
+    # measuring coverage of a pytest plugin using pytest-cov is slightly awkward,
+    # so we have a separate step for it
+    env: TOX_ENV=coverage
+
+  - <<: *default
     stage: pip_package
     install: true
     script: true

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@
     :target: https://ci.appveyor.com/project/pyviz/nbsmoke/branch/master
     :alt: See Build Status on AppVeyor
 
+.. image:: https://coveralls.io/repos/github/pyviz-dev/nbsmoke/badge.svg?branch=master
+    :target: https://coveralls.io/github/pyviz-dev/nbsmoke?branch=master
+    :alt: See coverage stats on Coveralls
 
 =======
 nbsmoke

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ passenv = TRAVIS TRAVIS_*
 commands = coverage run -m pytest -v {posargs:tests}
            coverage report -m
 	   coveralls
-deps = {[testenv]extras}
-       coveralls
+extras = all
+deps = coveralls
 
 [testenv:flake8]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ passenv = TRAVIS TRAVIS_*
 commands = coverage run -m pytest -v {posargs:tests}
            coverage report -m
 	   coveralls
-deps = {[testenv]deps}
+deps = {[testenv]extras}
        coveralls
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ passenv = TRAVIS TRAVIS_*
 # don't use pytest-cov as nbsmoke is itself a pytest plugin, so things
 # get confusing (e.g. nbsmoke gets imported before coverage collection
 # starts, so all the module-level code is missed)
-commands = coverage run -m pytest -v {posargs:tests}
+commands = coverage run --include=nbsmoke -m pytest
            coverage report -m
-	   coveralls
+           coveralls
 extras = all
 deps = coveralls
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,23 @@
 [tox]
 envlist = py27,py36,py37,py38,pypy,flake8,dev
 
-# TODO: shouldn't be 'all' in every case.
+# TODO: shouldn't be extras=all in every case.
 
 [testenv]
 commands = py.test -v {posargs:tests}
 extras = all
+
+[testenv:coverage]
+setdevelop = True
+passenv = TRAVIS TRAVIS_*
+# don't use pytest-cov as nbsmoke is itself a pytest plugin, so things
+# get confusing (e.g. nbsmoke gets imported before coverage collection
+# starts, so all the module-level code is missed)
+commands = coverage run -m pytest -v {posargs:tests}
+           coverage report -m
+	   coveralls
+deps = {[testenv]deps}
+       coveralls
 
 [testenv:flake8]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ passenv = TRAVIS TRAVIS_*
 # don't use pytest-cov as nbsmoke is itself a pytest plugin, so things
 # get confusing (e.g. nbsmoke gets imported before coverage collection
 # starts, so all the module-level code is missed)
-commands = coverage run --include=nbsmoke -m pytest
+commands = coverage run --source=nbsmoke -m pytest
            coverage report -m
            coveralls
 extras = all


### PR DESCRIPTION
Fixes #26

Using pytest-cov (a pytest plugin) to measure the coverage of nbsmoke - which is itself a pytest plugin - is a little bit tricky. So just use coverage without the pytest-cov plugin.