### PR TITLE
Quick sketch of switching to nbval to discover issues/plan how it would look

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,7 @@
 nbsmoke
 =======
 
-Basic notebook smoke tests: Do they run ok? Do they contain lint?
-
-----
-
-This `Pytest`_ plugin was generated with `Cookiecutter`_ along with `@hackebrot`_'s `Cookiecutter-pytest-plugin`_ template.
-
+Static checking of notebooks (e.g. do they contain lint?)
 
 
 Installation
@@ -29,22 +24,13 @@ You can install nbsmoke via `pip`_ from `PyPI`_::
 
     $ pip install nbsmoke
 
-Or you can install nbsmoke via `conda`_ from `anaconda.org`_::
+Or via `conda`_ from `anaconda.org`_::
 
-    $ conda install -c pyviz/label/dev -c conda-forge nbsmoke
+    $ conda install nbsmoke
 
 
 Usage
 -----
-
-Check all notebooks run without errors::
-
-    $ pytest --nbsmoke-run
-
-Check all notebooks run without errors, and store html to look at
-afterwards::
-
-    $ pytest --nbsmoke-run --store-html=/scratch
 
 Lint check notebooks::
 
@@ -56,8 +42,75 @@ Lint failures as warnings only::
 
 Instead of all files in a directory, you can specify a list e.g.::
 
-    $ pytest --nbsmoke-run notebooks/Untitled*.ipynb
+    $ pytest --nbsmoke-lint notebooks/Untitled*.ipynb
 
+If you want to restrict pytest to running only your notebook tests, use `-k`, e.g.::
+
+    $ pytest --nbsmoke-lint -k ".ipynb"
+
+TODO: add ``--nbsmoke-verify`` docs!
+    
+Additional options are available by standard pytest 'ini'
+configuration in setup.cfg, pytest.ini, or tox.ini::
+
+    [pytest]
+    # flakes you don't want to hear about (regex)
+    nbsmoke_flakes_to_ignore = .*hvplot.* imported but unused.*
+
+    # line magics to treat as being flakes (i.e. magics you don't want in your notebooks)
+    nbsmoke_flakes_line_magics_blacklist = pylab
+
+    # cell magics to treat as being flakes (i.e. magics you don't want in your notebooks)
+    nbsmoke_flakes_cell_magics_blacklist = bash
+                                           ruby
+
+
+nbsmoke supports ``# noqa`` comments to mark that something
+should be ignored during lint checking.
+
+
+What's the point?
+-----------------
+
+Checking notebooks for lint can find things like undefined names
+faster than by running them.
+
+TODO: be able to switch linter? Or explicitly call the "lint"
+pyflakes.
+
+Things that aren't errors, such as unused imports/names, might seem
+trivial, but they can hinder understanding of a notebook by readers,
+or add dependencies that are not required.
+
+Hopefully you don't have mysterious (unused) imports in your notebook,
+but if you do, you can add ``# noqa: explanation`` to stop flake
+errors.  E.g. if you're importing something for its side effects, it's
+very helpful to inform the reader of that.
+
+Pyflakes is used as the underlying linter because "Pyflakes makes a
+simple promise: it will never complain about style, and it will try
+very, very hard to never emit false positives."
+
+
+Deprecated Usage
+----------------
+
+nbsmoke used to support checking that notebooks run without error, and
+could save the generated html.  However, we now recommend using nbval
+instead. ``--nbsmoke-run`` is still available, but just calls nbval;
+eventually all options related to ``--nbsmoke-run`` will be removed from
+nbsmoke.
+
+Old...Check all notebooks run without errors::
+
+    $ pytest --nbsmoke-run
+
+New...Use nbval instead::
+
+    $ pytest --nbval-lax
+
+Old stuff...
+    
 If you want to restrict pytest to running only your notebook tests, use `-k`, e.g.::
 
     $ pytest --nbsmoke-run -k ".ipynb"
@@ -73,57 +126,10 @@ configuration in setup.cfg, pytest.ini, or tox.ini::
     nbsmoke_skip_run = ^.*skipme\.ipynb$
                        ^.*skipmetoo.*$
 
-    # case insensitive re to match for file to be considered notebook;
-    # defaults to ``^.*\.ipynb``
-    it_is_nb_file = ^.*\.something$
-
-    # flakes you don't want to hear about (regex)
-    nbsmoke_flakes_to_ignore = .*hvplot.* imported but unused.*
-
-    # line magics to treat as being flakes (i.e. magics you don't want in your notebooks)
-    nbsmoke_flakes_line_magics_blacklist = pylab
-
-    # cell magics to treat as being flakes (i.e. magics you don't want in your notebooks)
-    nbsmoke_flakes_cell_magics_blacklist = bash
-                                           ruby
-
-
-nbsmoke supports ``# noqa`` comments to mark that something
-should be ignored during lint checking.
 
 The ``nbsmoke_skip_run`` list in a project's config can be ignored by
 passing ``--ignore-nbsmoke-skip-run`` (useful if sometimes you want to
 run all notebooks for a project where many are typically skipped).
-
-
-What's the point?
------------------
-
-Although more sophisticated testing of notebooks is possible (e.g. see
-nbval), just checking that notebooks run from start to finish without
-error in a fresh kernel (or on a neutral CI service) can be useful
-during development. Practical experience of working on several
-projects with notebooks confirms this, but that's all the evidence I
-have.
-
-Checking notebooks for lint might seem trivial/pointless, but it
-frequently uncovers unused names (typically unused imports). It's also
-quite common to find python 2 vs 3 problems, and sometimes undefined
-names - in a way that's faster than running the notebook (over
-multiple versions of python).
-
-Unused imports/names themselves might seem trivial, but they can
-hinder understanding of a notebook by readers, or add dependencies
-that are not required.
-
-Hopefully you don't have mysterious (unused) imports in your notebook,
-but if you do, you can add ``# noqa: explanation`` to stop flake
-errors.  E.g. if you're importing something for its side effects, it's
-very helpful to inform the reader of that.
-
-Pyflakes is used as the underlying linter because "Pyflakes makes a
-simple promise: it will never complain about style, and it will try
-very, very hard to never emit false positives."
 
 
 Contributing
@@ -153,11 +159,8 @@ Issues
 If you encounter any problems, please `file an issue`_ (ideally
 including a copy of any problematic notebook).
 
-.. _`Cookiecutter`: https://github.com/audreyr/cookiecutter
-.. _`@hackebrot`: https://github.com/hackebrot
 .. _`BSD-3`: http://opensource.org/licenses/BSD-3-Clause
-.. _`cookiecutter-pytest-plugin`: https://github.com/pytest-dev/cookiecutter-pytest-plugin
-.. _`file an issue`: https://github.com/pyviz/nbsmoke/issues
+.. _`file an issue`: https://github.com/pyviz-dev/nbsmoke/issues
 .. _`pytest`: https://github.com/pytest-dev/pytest
 .. _`tox`: https://tox.readthedocs.io/en/latest/
 .. _`pip`: https://pypi.python.org/pypi/pip/

--- a/nbsmoke/__init__.py
+++ b/nbsmoke/__init__.py
@@ -1,18 +1,10 @@
 # -*- coding: utf-8 -*-
 
-# Note: created with cookiecutter by someone with no experience of how
-# to make a pytest plugin. Please question anything related to the
-# pytest integration!
-
 import re
 import os
 import io
-import contextlib
 
 import pytest
-import nbformat
-import nbconvert
-from nbconvert.preprocessors import ExecutePreprocessor
 
 try:
     from version import Version
@@ -30,10 +22,6 @@ from .verify import VerifyNb
 
 def pytest_addoption(parser):
     group = parser.getgroup('nbsmoke')
-    group.addoption(
-        '--nbsmoke-run',
-        action="store_true",
-        help="Run notebooks using nbconvert to check for exceptions.")
 
     group.addoption(
         '--nbsmoke-lint',
@@ -55,111 +43,61 @@ def pytest_addoption(parser):
         action="store_true",
         help="Verify notebooks")
 
-    group.addoption(
-        '--store-html',
-        action="store",
-        dest='store_html',
-        default='',
-        help="When running, store rendered-to-html notebooks in the supplied path.")
-
-    parser.addini('nbsmoke_cell_timeout', "nbsmoke's nbconvert cell timeout")
-
-    ####
-    # TODO: hacks to work around pyviz team desire to not use pytest's markers
-    parser.addini('nbsmoke_skip_run', 're to skip (multi-line; one pattern per line)')
-    group.addoption(
-        '--ignore-nbsmoke-skip-run',
-        action="store_true",
-        help="Ignore any skip list in the ini file (allows to run all nbs if desired)")
-    ####
-
-    # TODO: remove/rename/see pytest python_files
-    parser.addini('it_is_nb_file', 're to determine whether file is notebook')
-
     parser.addini('nbsmoke_flakes_to_ignore', "flake messages to ignore during nbsmoke's flake checking")
-
     parser.addini('nbsmoke_flakes_cell_magics_blacklist', "cell magics you don't want to see - i.e. treat as lint.")
     parser.addini('nbsmoke_flakes_line_magics_blacklist', "line magics you don't want to see - i.e. treat as lint")
 
 
-@contextlib.contextmanager
-def cwd(d):
-    orig = os.getcwd()
-    os.chdir(d)
-    try:
-        yield
-    finally:
-        os.chdir(orig)
+    ##################
+    ### DEPRECATED ###
+    group.addoption(
+        '--nbsmoke-run',
+        action="store_true",
+        help="**DEPRECATED: Use --nbval-lax instead** Run notebooks using nbconvert to check for exceptions.")
 
+    # TODO!
+    parser.addini('nbsmoke_cell_timeout', "nbsmoke's nbconvert cell timeout")
 
-
-###################################################
-
-
-class RunNb(pytest.Item):
-
-    def repr_failure(self, excinfo):
-        return excinfo.exconly(True)
-
-    def runtest(self):
-        self._skip()
-        with io.open(self.name,encoding='utf8') as nb:
-            notebook = nbformat.read(nb, as_version=4)
-
-            # TODO: which kernel? run in pytest's or use new one (make it option)
-            _timeout = self.parent.parent.config.getini('nbsmoke_cell_timeout')
-            kwargs = dict(timeout=int(_timeout) if _timeout!='' else 300,
-                          allow_errors=False,
-                          # or sys.version_info[1] ?
-                          kernel_name='python')
-
-            ep = ExecutePreprocessor(**kwargs)
-            with cwd(os.path.dirname(self.name)): # jupyter notebook always does this, right?
-                ep.preprocess(notebook,{})
-
-            # TODO: clean up this option handling
-            if self.parent.parent.config.option.store_html != '':
-                he = nbconvert.HTMLExporter()
-                # could maybe use this for chance of testing the html? but not the aim of this project
-                #he.template_file = 'basic'
-                html, resources = he.from_notebook_node(notebook)
-                with io.open(os.path.join(self.parent.parent.config.option.store_html,os.path.basename(self.name)+'.html'),'w',encoding='utf8') as f:
-                    f.write(html)
-
-    def _skip(self):
-        _skip_patterns = self.parent.parent.config.getini('nbsmoke_skip_run')
-        if not self.parent.parent.config.option.ignore_nbsmoke_skip_run:
-            for pattern in _skip_patterns.splitlines():
-                if re.match(pattern,self.nodeid.split("::")[0],re.IGNORECASE):
-                    pytest.skip()
-
+    # TODO: hacks to work around pyviz team desire to not use pytest's markers
+    parser.addini('nbsmoke_skip_run', '**DEPRECATED: something something!** re to skip (multi-line; one pattern per line)')
+    group.addoption(
+        '--ignore-nbsmoke-skip-run',
+        action="store_true",
+        help="**DEPRECATED: something something!** Ignore any skip list in the ini file (allows to run all nbs if desired)")
+    ####
+    ##################
+    
 
 class IPyNbFile(pytest.File):
-    def __init__(self, fspath, parent=None, config=None, session=None, dowhat=RunNb):
-        self._dowhat = dowhat
+    def __init__(self, type_, fspath, parent=None, config=None, session=None):
+        self._type = type_
         super(IPyNbFile,self).__init__(fspath, parent=parent, config=None, session=None)
 
     def collect(self):
-        yield self._dowhat(str(self.fspath), self)
+        yield self._type(str(self.fspath), self)
 
-
+        
 def pytest_collect_file(path, parent):
+    if not path.fnmatch("*.ipynb"):
+        return
+
     opt = parent.config.option
-    # TODO: Make this pattern standard/configurable.
-    # match .ipynb except .nbval.ipynb
-    it_is_nb_file = parent.config.getini('it_is_nb_file')
-    if it_is_nb_file == '':
-        #"^((?!\.nbval).)*\.ipynb$"
-        it_is_nb_file = r"^.*\.ipynb"
-    if re.match(it_is_nb_file,path.strpath,re.IGNORECASE):
-        if opt.nbsmoke_run or opt.nbsmoke_lint or opt.nbsmoke_verify:
-            # TODO express via the options system if you ever figure it out
-            # Hmm, should be able to do all - clean up!
-            assert (opt.nbsmoke_run ^ opt.nbsmoke_lint) ^ opt.nbsmoke_verify
-            if opt.nbsmoke_run:
-                dowhat = RunNb
-            elif opt.nbsmoke_lint:
-                dowhat = LintNb
-            elif opt.nbsmoke_verify:
-                dowhat = VerifyNb
-            return IPyNbFile(path, parent, dowhat=dowhat)
+
+    # you have to pick one - can't currently run and lint and verify
+    # (though you should be able to)
+    
+    if opt.nbsmoke_run:
+        import nbval.plugin        
+        # TODO: emit a deprecation warning
+        _skip_patterns = parent.config.getini('nbsmoke_skip_run')
+        # if skip_patterns: emit another deprecation warning!
+        if opt.ignore_nbsmoke_skip_run:
+            # TODO: emit another deprecation warning!!
+            _skip_patterns = []
+        nbval.plugin.IPyNbFile._skip_patterns = _skip_patterns
+        return nbval.plugin.IPyNbFile(path, parent)
+    
+    elif opt.nbsmoke_lint:
+        return IPyNbFile(LintNb, path, parent)
+    elif opt.nbsmoke_verify:
+        return IPyNbFile(VerifyNb, path, parent)

--- a/setup.py
+++ b/setup.py
@@ -7,24 +7,24 @@ from setuptools import setup, find_packages
 
 import version
 
-
 def read(fname):
     file_path = os.path.join(os.path.dirname(__file__), fname)
     return codecs.open(file_path, encoding='utf-8').read()
 
 extras_require = {
+    'run-checks': ['nbval'],
     'holoviews-magics': ['holoviews'],
     'verify': ['requests', 'beautifulsoup4'],
 }
 
 setup_args = dict(
     name='nbsmoke',
-    description='Basic notebook checks. Do they run? Do they contain lint?',
+    description='Static checking of Jupyter notebooks.',
     version = version.get_setup_version('nbsmoke'),
-    url='https://github.com/pyviz/nbsmoke',
+    url='https://github.com/pyviz-dev/nbsmoke',
     long_description=read('README.rst'),    
-    author='pyviz contributors',
-    author_email = "dev@pyviz.org",
+    author='pyviz-dev contributors',
+    author_email = "developers@holoviz.org",
     license='BSD-3',
     packages=find_packages(),
     include_package_data = True,
@@ -39,25 +39,16 @@ setup_args = dict(
         'Operating System :: OS Independent',
         'License :: OSI Approved :: BSD License',
     ],
-    
-    python_requires = ">=2.7",
-    
+    python_requires = ">=2.7",    
     install_requires=[
         'pytest >=3.1.1',
         ########## lint stuff
         'pyflakes',
-        ########## notebook stuff (reading, executing)
+        ########## notebook stuff
         # * Required imports: nbconvert, nbformat.
-        # * Need to be able to execute ipython notebooks.
         # * Optional: process ipython magics (required import: IPython)
-        'jupyter_client',
         'nbformat',
         'nbconvert',
-    # TODO: I think the decision was to go with python/setup.py for this stuff,
-    # right? (but if so, how do I specify it's the runtime python version
-    # I'm talking aobut, not the buildtime python version?)
-    # Also - not sure exactly what is required now
-    ] + (['ipykernel'] if (sys.version_info[0]>=3 and sys.version_info[1]>4) else ['ipykernel <5']),
     extras_require = extras_require,
     entry_points={
         'pytest11': [

--- a/tests/test_nbsmoke.py
+++ b/tests/test_nbsmoke.py
@@ -8,11 +8,12 @@ def test_help_message(testdir):
     )
     result.stdout.fnmatch_lines([
         'nbsmoke:',
-        '*--nbsmoke-run*',
         '*--nbsmoke-lint*',
+        '*--nbsmoke-lint-debug*',        
         '*--nbsmoke-lint-onlywarn*',
         '*--nbsmoke-verify*',
-        '*--store-html*'
+        '*--nbsmoke-run*',
+        '*--ignore-nbsmoke-skip-run*',        
     ])
 
 
@@ -40,14 +41,3 @@ def test_nbsmoke_cell_timeout_ini_setting(testdir):
     ])
 
     assert result.ret == 0
-
-    
-def test_it_is_nbfile(testdir):
-    testdir.makeini(r"""
-        [pytest]
-        it_is_nb_file = ^.*\.something$
-    """)
-    testdir.makefile('.ipynb', testing123=nb_basic%{'the_source':"1/0"})
-    result = testdir.runpytest('--nbsmoke-run','-v')
-    assert result.ret == 5
-    result.stdout.fnmatch_lines(['*collected 0 items*'])


### PR DESCRIPTION
* recommend to use `--nbval-lax` instead of `--nbsmoke-run`
* drop support for saving html
* use `--nbval-lax` to replace `--nbsmoke-run`.

To do:
* [ ] nbval does not support config file?
* [ ] nbval does not support skipping a notebook (except by comment on every cell)
* [ ] nbval does not record/show its own test coverage anywhere

Also:
  * update metadata
  * define a notebook file as simply being fnmatch *.ipynb
