### PR TITLE
Update deprecated pytest api

### DIFF
--- a/nbsmoke/__init__.py
+++ b/nbsmoke/__init__.py
@@ -140,7 +140,10 @@ class IPyNbFile(pytest.File):
         super(IPyNbFile,self).__init__(fspath, parent=parent, config=None, session=None)
 
     def collect(self):
-        yield self._dowhat(str(self.fspath), self)
+        if hasattr(self._dowhat, "from_parent"):
+            yield self._dowhat.from_parent(parent, fspath=path)
+        else:
+            yield self._dowhat(str(self.fspath), self)
 
 
 def pytest_collect_file(path, parent):

--- a/nbsmoke/__init__.py
+++ b/nbsmoke/__init__.py
@@ -140,10 +140,7 @@ class IPyNbFile(pytest.File):
         super(IPyNbFile,self).__init__(fspath, parent=parent, config=None, session=None)
 
     def collect(self):
-        if hasattr(self._dowhat, "from_parent"):
-            yield self._dowhat.from_parent(self, fspath=self.fspath)
-        else:
-            yield self._dowhat(str(self.fspath), self)
+        yield self._dowhat(str(self.fspath), self)            
 
 
 def pytest_collect_file(path, parent):

--- a/nbsmoke/__init__.py
+++ b/nbsmoke/__init__.py
@@ -141,7 +141,7 @@ class IPyNbFile(pytest.File):
 
     def collect(self):
         if hasattr(self._dowhat, "from_parent"):
-            yield self._dowhat.from_parent(parent, fspath=path)
+            yield self._dowhat.from_parent(self, fspath=self.fspath)
         else:
             yield self._dowhat(str(self.fspath), self)
 

--- a/nbsmoke/__init__.py
+++ b/nbsmoke/__init__.py
@@ -164,6 +164,6 @@ def pytest_collect_file(path, parent):
                 dowhat = VerifyNb
 
             if hasattr(IPyNbFile, "from_parent"):
-                return IPyNbFile.from_parent(parent, fspath=path)
+                return IPyNbFile.from_parent(parent, fspath=path, dowhat=dowhat)
             
             return IPyNbFile(path, parent, dowhat=dowhat)

--- a/nbsmoke/__init__.py
+++ b/nbsmoke/__init__.py
@@ -162,4 +162,8 @@ def pytest_collect_file(path, parent):
                 dowhat = LintNb
             elif opt.nbsmoke_verify:
                 dowhat = VerifyNb
+
+            if hasattr(IPyNbFile, "from_parent"):
+                return IPyNbFile.from_parent(parent, fspath=path)
+            
             return IPyNbFile(path, parent, dowhat=dowhat)


### PR DESCRIPTION
Pytest recently deprecated how modules are instantiated modules that causes ci [failures](https://travis-ci.org/github/holoviz/hvplot/jobs/723528522#L1370). I ran into this issue on a different project https://github.com/deathbeds/importnb/pull/103/files

This pr adds logic for the newest api.